### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,6 @@
 | --- | --- | 
 | Andi Gunderson | agunde406 |
 | Dan Middleton | dcmiddle |
-| Dave Cecchi | davececchi |
 | James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
 | Shawn Amundson | vaporos |
@@ -13,4 +12,5 @@
 ### Retired Maintainers
 | Name | GitHub |
 | --- | --- | 
+| Dave Cecchi | davececchi |
 | Gari Singh | mastersingh24 |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>